### PR TITLE
Configure Dependabot for all composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # Enable version updates for GitHub Actions in workflow files
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every day
+      interval: "daily"
+    commit-message:
+      prefix: "ci:"
+      include: "scope"
+    
+  # Enable version updates for GitHub Actions in all composite actions
+  - package-ecosystem: "github-actions"
+    directory: "/**/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "ci:"
+      include: "scope"
+    
+  # Enable version updates for Python packages
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      # Check for updates to Python packages every day
+      interval: "daily"
+    commit-message:
+      prefix: "deps:"
+      include: "scope" 


### PR DESCRIPTION
This PR configures Dependabot to check for updates to GitHub Actions used in all composite actions in the repository. It also maintains the daily update schedule for both GitHub Actions and Python packages.